### PR TITLE
solution to >php7.3 regex warning when dash is not escaped

### DIFF
--- a/src/Helper/ApiHelper.php
+++ b/src/Helper/ApiHelper.php
@@ -89,7 +89,7 @@ final class ApiHelper
 
     public function getItemUriPattern(\ReflectionClass $reflectionClass): string
     {
-        return str_replace(urlencode('{id}'), '[\\w-;=]+', urldecode($this->getItemUri($reflectionClass, ['id' => '{id}'])));
+        return str_replace(urlencode('{id}'), '[\\w\-;=]+', urldecode($this->getItemUri($reflectionClass, ['id' => '{id}'])));
     }
 
     public function getObjectIdentifiers($object): array


### PR DESCRIPTION
preg_match(): Compilation failed: invalid range in character class at offset
